### PR TITLE
Added gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.ipynb_checkpoints


### PR DESCRIPTION
The `.ipynb_checkpoints` is generated on my windows installation, and should not be taken into git.